### PR TITLE
Updated Read Me & Documentation in the code. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 lib/
 old
 .vscode
+.idea
 serializr.min.js*
 coverage
 *.log

--- a/README.md
+++ b/README.md
@@ -144,12 +144,14 @@ const message = deserialize(Message, {
 
 
 console.dir(message, {colors: true, depth: 10});
+
+// We can call serialize without the first argument here
+//because the schema can be inferred from the decorated classes
+ 
 const json = serialize(message);
 ```
 
-
 **Decorator: Caveats**
-
 
 Babel 6.x does not allow decorators to self-reference during their creation, so the above code would not work for the Message class. Instead write:
 
@@ -166,9 +168,7 @@ class Message {
     constructor(){
         getDefaultModelSchema(Message).props["comments"] = list(object(Message));
     }
-}
-
-And then call `serialize` without the first argument. 
+} 
 ```
 
 ## Enabling decorators (optional)
@@ -197,7 +197,6 @@ Install support for decorators: `npm i --save-dev babel-plugin-transform-decorat
 ```
 
 Probably you have more plugins and presets in your `.babelrc` already, note that the order is important and `transform-decorators-legacy` should come as first.
-
 
 # Concepts
 
@@ -232,9 +231,9 @@ See the examples below.
 
 ## PropSchema
 
-Prop schemas contain the strategy on how individual fields should be serialized.
+PropSchemas contain the strategy on how individual fields should be serialized.
 It denotes whether a field is a primitive, list, whether it needs to be aliased, refers to other model objects etc.
-Propschemas are composable. See the API section below for the details, but these are the built-in property schemas:
+PropSchemas are composable. See the API section below for the details, but these are the built-in property schemas:
 
 -   `primitive()`: Serialize a field as primitive value
 -   `identifier()`: Serialize a field as primitive value, use it as identifier when serializing references (see `reference`)
@@ -249,7 +248,7 @@ Propschemas are composable. See the API section below for the details, but these
 
 It is possible to define your own prop schemas. You can define your own propSchema by creating a function that returns an object with the following signature:
 
-```javascript
+```typings
 {
     serializer: (sourcePropertyValue: any) => jsonValue,
     deserializer: (jsonValue: any, callback: (err, targetPropertyValue: any) => void, context?, currentPropertyValue?) => void
@@ -276,9 +275,53 @@ When deserializing a model elememt / property, the following fields are availabl
 
 # API
 
+## ModelSchema
+
+[serializr.js:127-134](https://github.com/KaySackey/serializr/blob/e41f194f2365ea6210bbd6f6d65995fd08afa4c7/serializr.js#L127-L134 "Source code on GitHub")
+
+Prop Schema
+
+**Parameters**
+
+-   `value` **Any** 
+-   `targetClass`  
+-   `get` **([Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function) \| [undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined))** 
+-   `set` **([Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function) \| [undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined))** 
+-   `configurable` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+-   `enumerable` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+-   `sourcePropertyValue` **Any** 
+-   `jsonValue` **Any** 
+-   `callback` **cpsCallback** 
+-   `context` **Context** 
+-   `writeable` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+-   `id` **Any** 
+-   `target` **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `context` **Context** 
+-   `result` **Any** 
+-   `error` **Any** 
+-   `id` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `callback` **cpsCallback** 
+-   `factory`  
+-   `props`  
+-   `currentPropertyValue` **Any** 
+
+**Properties**
+
+-   `serializer` **serializerFunction** 
+-   `deserializer` **deserializerFunction** 
+-   `identifier` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **Any** any - serialized object
+
+Returns **Any** void
+
+Returns **Any** void
+
+Returns **Any** void
+
 ## createSimpleSchema
 
-[serializr.js:79-86](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L79-L86 "Source code on GitHub")
+[serializr.js:127-134](https://github.com/KaySackey/serializr/blob/e41f194f2365ea6210bbd6f6d65995fd08afa4c7/serializr.js#L127-L134 "Source code on GitHub")
 
 Creates a model schema that (de)serializes from / to plain javascript objects.
 Its factory method is: `() => ({})`
@@ -293,7 +336,7 @@ Its factory method is: `() => ({})`
 var todoSchema = createSimpleSchema({
   title: true,
   done: true
-};
+});
 
 var json = serialize(todoSchema, { title: "Test", done: false })
 var todo = deserialize(todoSchema, json)
@@ -303,7 +346,7 @@ Returns **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 ## createModelSchema
 
-[serializr.js:112-130](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L112-L130 "Source code on GitHub")
+[serializr.js:160-178](https://github.com/KaySackey/serializr/blob/e41f194f2365ea6210bbd6f6d65995fd08afa4c7/serializr.js#L160-L178 "Source code on GitHub")
 
 Creates a model schema that (de)serializes an object created by a constructor function (class).
 The created model schema is associated by the targeted type as default model schema, see setDefaultModelSchema.
@@ -311,9 +354,9 @@ Its factory method is `() => new clazz()` (unless overriden, see third arg).
 
 **Parameters**
 
--   `clazz` **[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** class or constructor function
+-   `clazz` **([constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor) | class)** class or constructor function
 -   `props` **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** property mapping
--   `factory` **[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** optional custom factory. Receives context as first arg.
+-   `factory` **[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** optional custom factory. Receives context as first arg
 
 **Examples**
 
@@ -336,16 +379,16 @@ Returns **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 ## serializable
 
-[serializr.js:158-168](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L158-L168 "Source code on GitHub")
+[serializr.js:206-216](https://github.com/KaySackey/serializr/blob/e41f194f2365ea6210bbd6f6d65995fd08afa4c7/serializr.js#L206-L216 "Source code on GitHub")
 
 Decorator that defines a new property mapping on the default model schema for the class
 it is used in.
 
 **Parameters**
 
--   `arg1`
--   `arg2`
--   `arg3`
+-   `arg1`  
+-   `arg2`  
+-   `arg3`  
 
 **Examples**
 
@@ -353,42 +396,41 @@ it is used in.
 class Todo {
 ```
 
-Returns **PropertyDescriptor**
+Returns **PropertyDescriptor** 
 
 ## getDefaultModelSchema
 
-[serializr.js:192-201](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L192-L201 "Source code on GitHub")
+[serializr.js:284-293](https://github.com/KaySackey/serializr/blob/e41f194f2365ea6210bbd6f6d65995fd08afa4c7/serializr.js#L284-L293 "Source code on GitHub")
 
 Returns the standard model schema associated with a class / constructor function
 
 **Parameters**
 
--   `clazz` **[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** class or constructor function
--   `thing`
+-   `thing` **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
-Returns **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** model schema
+Returns **[ModelSchema](#modelschema)** model schema
 
 ## setDefaultModelSchema
 
-[serializr.js:214-217](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L214-L217 "Source code on GitHub")
+[serializr.js:307-310](https://github.com/KaySackey/serializr/blob/e41f194f2365ea6210bbd6f6d65995fd08afa4c7/serializr.js#L307-L310 "Source code on GitHub")
 
 Sets the default model schema for class / constructor function.
-Wherever a model schema is required as argument, this class / constructor function
-can be passed in as well (for example when using `object` or `reference`.
+Everywhere where a model schema is required as argument, this class / constructor function
+can be passed in as well (for example when using `object` or `ref`.
 
 When passing an instance of this class to `serialize`, it is not required to pass the model schema
 as first argument anymore, because the default schema will be inferred from the instance type.
 
 **Parameters**
 
--   `clazz` **[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** class or constructor function
--   `modelSchema`
+-   `clazz` **([constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor) | class)** class or constructor function
+-   `modelSchema` **[ModelSchema](#modelschema)** a model schema
 
-Returns **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** model schema
+Returns **[ModelSchema](#modelschema)** model schema
 
 ## serialize
 
-[serializr.js:269-287](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L269-L287 "Source code on GitHub")
+[serializr.js:362-380](https://github.com/KaySackey/serializr/blob/e41f194f2365ea6210bbd6f6d65995fd08afa4c7/serializr.js#L362-L380 "Source code on GitHub")
 
 Serializes an object (graph) into json using the provided model schema.
 The model schema can be omitted if the object type has a default model schema associated with it.
@@ -403,24 +445,26 @@ Returns **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 ## deserialize
 
-[serializr.js:341-359](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L341-L359 "Source code on GitHub")
+[serializr.js:434-452](https://github.com/KaySackey/serializr/blob/e41f194f2365ea6210bbd6f6d65995fd08afa4c7/serializr.js#L434-L452 "Source code on GitHub")
 
 Deserializes a json structor into an object graph.
 This process might be asynchronous (for example if there are references with an asynchronous
 lookup function). The function returns an object (or array of objects), but the returned object
-might be incomplete until the callback has fired as well (which might happen immediately). 
+might be incomplete until the callback has fired as well (which might happen immediately)
 
 **Parameters**
 
--   `schema`
+-   `schema` **([object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) \| [array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array))** to use for deserialization
 -   `json` **[json](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON)** data to deserialize
 -   `callback` **[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** node style callback that is invoked once the deserializaiton has finished.
     First argument is the optional error, second argument is the deserialized object (same as the return value)
--   `customArgs` **any** custom arguments that are available as `context.args` during the deserialization process. This can be used as dependency injection mechanism to pass in, for example, stores.
+-   `customArgs` **Any** custom arguments that are available as `context.args` during the deserialization process. This can be used as dependency injection mechanism to pass in, for example, stores.
+
+Returns **([object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) \| [array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array))** deserialized object, possibly incomplete.
 
 ## update
 
-[serializr.js:525-544](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L525-L544 "Source code on GitHub")
+[serializr.js:618-637](https://github.com/KaySackey/serializr/blob/e41f194f2365ea6210bbd6f6d65995fd08afa4c7/serializr.js#L618-L637 "Source code on GitHub")
 
 Similar to deserialize, but updates an existing object instance.
 Properties will always updated entirely, but properties not present in the json will be kept as is.
@@ -432,11 +476,11 @@ Further this method behaves similar to deserialize.
 -   `target` **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** target instance to update
 -   `json` **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** the json to deserialize
 -   `callback` **[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** the callback to invoke once deserialization has completed.
--   `customArgs` **any** custom arguments that are available as `context.args` during the deserialization process. This can be used as dependency injection mechanism to pass in, for example, stores.
+-   `customArgs` **Any** custom arguments that are available as `context.args` during the deserialization process. This can be used as dependency injection mechanism to pass in, for example, stores.
 
 ## primitive
 
-[serializr.js:566-578](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L566-L578 "Source code on GitHub")
+[serializr.js:659-671](https://github.com/KaySackey/serializr/blob/e41f194f2365ea6210bbd6f6d65995fd08afa4c7/serializr.js#L659-L671 "Source code on GitHub")
 
 Indicates that this field contains a primitive value (or Date) which should be serialized literally to json.
 
@@ -451,22 +495,23 @@ console.dir(serialize(new Todo("test")))
 // outputs: { title : "test" }
 ```
 
-Returns **PropSchema**
+Returns **[ModelSchema](#modelschema)** 
 
 ## identifier
 
-[serializr.js:613-627](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L613-L627 "Source code on GitHub")
+[serializr.js:710-724](https://github.com/KaySackey/serializr/blob/e41f194f2365ea6210bbd6f6d65995fd08afa4c7/serializr.js#L710-L724 "Source code on GitHub")
 
 Similar to primitive, but this field will be marked as the identifier for the given Model type.
 This is used by for example `reference()` to serialize the reference
 
 Identifier accepts an optional `registerFn` with the signature:
 `(id, target, context) => void`
-that can be used to register this object in some store. note that not all fields of this object might have been deserialized yet. 
+that can be used to register this object in some store. note that not all fields of this object might
+have been deserialized yet.
 
 **Parameters**
 
--   `registerFn` **[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** optional function to register this object during creation.
+-   `registerFn` **RegisterFunction** optional function to register this object during creation.
 
 **Examples**
 
@@ -492,25 +537,24 @@ t.deepEqual(todos, {
 })
 ```
 
-Returns **PropSchema**
+Returns **PropSchema** 
 
 ## date
 
-[serializr.js:638-653](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L638-L653 "Source code on GitHub")
+[serializr.js:735-750](https://github.com/KaySackey/serializr/blob/e41f194f2365ea6210bbd6f6d65995fd08afa4c7/serializr.js#L735-L750 "Source code on GitHub")
 
 Similar to primitive, serializes instances of Date objects
 
 ## alias
 
-[serializr.js:672-683](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L672-L683 "Source code on GitHub")
+[serializr.js:769-780](https://github.com/KaySackey/serializr/blob/e41f194f2365ea6210bbd6f6d65995fd08afa4c7/serializr.js#L769-L780 "Source code on GitHub")
 
 Alias indicates that this model property should be named differently in the generated json.
 Alias should be the outermost propschema.
 
 **Parameters**
 
--   `alias` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** name of the json field to be used for this property
--   `name`
+-   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** name of the json field to be used for this property
 -   `propSchema` **PropSchema** propSchema to (de)serialize the contents of this field
 
 **Examples**
@@ -524,11 +568,11 @@ console.dir(serialize(new Todo("test")))
 // { task : "test" }
 ```
 
-Returns **PropSchema**
+Returns **PropSchema** 
 
 ## custom
 
-[serializr.js:702-711](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L702-L711 "Source code on GitHub")
+[serializr.js:799-808](https://github.com/KaySackey/serializr/blob/e41f194f2365ea6210bbd6f6d65995fd08afa4c7/serializr.js#L799-L808 "Source code on GitHub")
 
 Can be used to create simple custom propSchema.
 
@@ -550,45 +594,48 @@ t.deepEqual(_.serialize(s, { a: 4 }), { a: 6 })
 t.deepEqual(_.deserialize(s, { a: 6 }), { a: 4 })
 ```
 
-Returns **propSchema**
+Returns **PropSchema** 
 
 ## object
 
-[serializr.js:738-756](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L738-L756 "Source code on GitHub")
+[serializr.js:839-857](https://github.com/KaySackey/serializr/blob/e41f194f2365ea6210bbd6f6d65995fd08afa4c7/serializr.js#L839-L857 "Source code on GitHub")
 
 `object` indicates that this property contains an object that needs to be (de)serialized
 using its own model schema.
 
-N.B. mind issues with circular dependencies when importing model schemas from other files! The module resolve algorithm might expose classes before `createModelSchema` is executed for the target class.
+N.B. mind issues with circular dependencies when importing model schema's from other files! The module resolve algorithm might expose classes before `createModelSchema` is executed for the target class.
 
 **Parameters**
 
--   `modelSchema` **modelSchema** to be used to (de)serialize the child
+-   `modelSchema` **[ModelSchema](#modelschema)** to be used to (de)serialize the object
 
 **Examples**
 
 ```javascript
+class SubTask{}
+class Todo{}
+
 createModelSchema(SubTask, {
   title: true
-})
+});
 createModelSchema(Todo, {
-  title: true
+  title: true,
   subTask: object(SubTask)
-})
+});
 
 const todo = deserialize(Todo, {
   title: "Task",
   subTask: {
     title: "Sub task"
   }
-})
+});
 ```
 
-Returns **PropSchema**
+Returns **PropSchema** 
 
 ## reference
 
-[serializr.js:810-843](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L810-L843 "Source code on GitHub")
+[serializr.js:916-949](https://github.com/KaySackey/serializr/blob/e41f194f2365ea6210bbd6f6d65995fd08afa4c7/serializr.js#L916-L949 "Source code on GitHub")
 
 `reference` can be used to (de)serialize references that point to other models.
 
@@ -606,24 +653,26 @@ an object. Its signature should be as follows:
 
 The lookupFunction is optional. If it is not provided, it will try to find an object of the expected type and required identifier within the same JSON document
 
-N.B. mind issues with circular dependencies when importing model schema's from other files! The module resolve algorithm might expose classes before `createModelSchema` is executed for the target class.
+N.B. mind issues with circular dependencies when importing model schemas from other files! The module resolve algorithm might expose classes before `createModelSchema` is executed for the target class.
 
 **Parameters**
 
 -   `target`  : ModelSchema or string
--   `lookup` **[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** function
--   `lookupFn`
+-   `lookupFn` **RefLookupFunction** function
 
 **Examples**
 
 ```javascript
+class User{}
+class Post{}
+
 createModelSchema(User, {
   uuid: identifier(),
   displayname: primitive()
 })
 
 createModelSchema(Post, {
-  author: reference(User, findUserById)
+  author: reference(User, findUserById),
   message: primitive()
 })
 
@@ -647,11 +696,11 @@ deserialize(
 )
 ```
 
-Returns **PropSchema**
+Returns **PropSchema** 
 
 ## list
 
-[serializr.js:875-896](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L875-L896 "Source code on GitHub")
+[serializr.js:986-1007](https://github.com/KaySackey/serializr/blob/e41f194f2365ea6210bbd6f6d65995fd08afa4c7/serializr.js#L986-L1007 "Source code on GitHub")
 
 List indicates that this property contains a list of things.
 Accepts a sub model schema to serialize the contents
@@ -663,12 +712,16 @@ Accepts a sub model schema to serialize the contents
 **Examples**
 
 ```javascript
+class SubTask{}
+class Task{}
+class Todo{}
+
 createModelSchema(SubTask, {
   title: true
 })
 createModelSchema(Todo, {
-  title: true
-  subTask: list(child(SubTask))
+  title: true,
+  subTask: list(object(SubTask))
 })
 
 const todo = deserialize(Todo, {
@@ -679,11 +732,11 @@ const todo = deserialize(Todo, {
 })
 ```
 
-Returns **PropSchema**
+Returns **PropSchema** 
 
 ## map
 
-[serializr.js:910-959](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L910-L959 "Source code on GitHub")
+[serializr.js:1021-1070](https://github.com/KaySackey/serializr/blob/e41f194f2365ea6210bbd6f6d65995fd08afa4c7/serializr.js#L1021-L1070 "Source code on GitHub")
 
 Similar to list, but map represents a string keyed dynamic collection.
 This can be both plain objects (default) or ES6 Map like structures.
@@ -691,7 +744,7 @@ This will be inferred from the initial value of the targetted attribute.
 
 **Parameters**
 
--   `propSchema` **any**
+-   `propSchema` **Any** 
 
 # Recipes and examples
 
@@ -830,7 +883,6 @@ const user = deserialize(
 ## 7. Putting it together: MobX store with plain objects, classes and internal references
 
 ```javascript
-
 // models.js:
 import {observable, computed} from 'mobx';
 import {serializable, identifier} from 'serializr';

--- a/README.md
+++ b/README.md
@@ -38,48 +38,65 @@ From CDN: <https://npmcdn.com/serializr> which declares the global `serializr` o
 
 ```javascript
 import {
-    createModelSchema, primitive, reference, list, object, identifier, serialize, deserialize
+  createModelSchema, primitive, reference, list, object, identifier, serialize, deserialize
 } from "serializr";
 
 // Example model classes
 class User {
-    uuid = Math.random();
+    uuid        = Math.random();
     displayName = "John Doe";
 }
 
 class Message {
-    message = "Test";
-    author = null;
+    message  = "Test";
+    author   = null;
     comments = [];
 }
 
-findUserById(uuid, callback) {
+function fetchUserSomewhere(uuid) {
+    // Lets pretend to actually fetch a user; but not.
+    // In a real app this might be a database query
+    const user       = new User();
+    user.uuid        = uuid;
+    user.displayName = `John Doe ${uuid}`;
+    return user;
+}
+
+function findUserById(uuid, callback, context) {
+    // This is a lookup function
+    // identifier is the identifier being resolved
+    // callback is a node style calblack function to be invoked with the found object (as second arg) or an error (first arg)
+    // context is an object detailing the execution context of the serializer now
     callback(null, fetchUserSomewhere(uuid))
 }
 
 // Create model schemas
 createModelSchema(Message, {
-    message: primitive(),
-    author: reference(User, findUserById),
+    message : primitive(),
+    author  : reference(User, findUserById),
     comments: list(object(Message))
-})
+});
 
 createModelSchema(User, {
-    uuid: identifier(),
+    uuid       : identifier(),
     displayName: primitive()
-})
+});
 
 // can now deserialize and serialize!
 const message = deserialize(Message, {
-    message: "Hello world",
-    author: 17,
-    comments: [{
-        message: "Welcome!",
-        author: 23
-    }]
-})
+    message : "Hello world",
+    author  : 17,
+    comments: [
+        {
+            message: "Welcome!",
+            author : 23
+        }
+    ]
+});
 
-const json = serialize(message)
+const json = serialize(message);
+
+console.dir(message, {colors: true, depth: 10});
 ```
 
 ## Using decorators (optional)

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ class Message {
         getDefaultModelSchema(Message).props["comments"] = list(object(Message));
     }
 }
+
+And then call `serialize` without the first argument. 
 ```
 
 ## Enabling decorators (optional)
@@ -207,7 +209,7 @@ What are those model schemas?
 The driving concept behind (de)serialization is a ModelSchema.
 It describes how model object instances can be (de)serialize to json.
 
-A model schema simple looks like this:
+A simple model schema looks like this:
 
 ```javascript
 const todoSchema = {
@@ -220,22 +222,22 @@ const todoSchema = {
 ```
 
 The `factory` tells how to construct new instances during deserialization.
-The optional `extends` property denotes that this model schema inherits it's props from another model schema.
-The props section describe how individual model properties are to be (de)serialized. Their names match the model field names.
+The optional `extends` property denotes that this model schema inherits its props from another model schema.
+The props section describes how individual model properties are to be (de)serialized. Their names match the model field names.
 The combination `fieldname: true` is simply a shorthand for `fieldname: primitive()`
 
 For convenience, model schemas can be stored on the constructor function of a class.
-This allows you to pass in a class reference everywhere where a model schema is required.
+This allows you to pass in a class reference wherever a model schema is required.
 See the examples below.
 
 ## PropSchema
 
 Prop schemas contain the strategy on how individual fields should be serialized.
 It denotes whether a field is a primitive, list, whether it needs to be aliased, refers to other model objects etc.
-Propschemas are composable. See the API section below for the details, but these are the built in property schemas:
+Propschemas are composable. See the API section below for the details, but these are the built-in property schemas:
 
 -   `primitive()`: Serialize a field as primitive value
--   `identifier()`: Serialize a field as primitive value, use it as identifier when serializing references (see `ref`)
+-   `identifier()`: Serialize a field as primitive value, use it as identifier when serializing references (see `reference`)
 -   `date()`: Serializes dates (as epoch number)
 -   `alias(name, propSchema)`: Serializes a field under a different name
 -   `list(propSchema)`: Serializes an array based collection
@@ -254,11 +256,11 @@ It is possible to define your own prop schemas. You can define your own propSche
 }
 ```
 
-For inspiration, take a look at the source code of the existing ones on how they work, it is pretty straight forward.
+For inspiration, take a look at the source code of the existing ones on how they work, it is pretty straightforward.
 
 ## Deserialization context
 
-The context object is an advanced feature and can be used to obtain additional context related information about the deserialization process.
+The context object is an advanced feature and can be used to obtain additional context-related information about the deserialization process.
 `context` is available as:
 
 1.  first argument of factory functions
@@ -279,7 +281,7 @@ When deserializing a model elememt / property, the following fields are availabl
 [serializr.js:79-86](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L79-L86 "Source code on GitHub")
 
 Creates a model schema that (de)serializes from / to plain javascript objects.
-It's factory method is: `() => ({})`
+Its factory method is: `() => ({})`
 
 **Parameters**
 
@@ -305,13 +307,13 @@ Returns **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 Creates a model schema that (de)serializes an object created by a constructor function (class).
 The created model schema is associated by the targeted type as default model schema, see setDefaultModelSchema.
-It's factory method is `() => new clazz()` (unless overriden, see third arg).
+Its factory method is `() => new clazz()` (unless overriden, see third arg).
 
 **Parameters**
 
--   `clazz` **[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** clazz or constructor function
+-   `clazz` **[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** class or constructor function
 -   `props` **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** property mapping
--   `factory` **[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** optional custom factory. Receives context as first arg
+-   `factory` **[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** optional custom factory. Receives context as first arg.
 
 **Examples**
 
@@ -371,8 +373,8 @@ Returns **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 [serializr.js:214-217](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L214-L217 "Source code on GitHub")
 
 Sets the default model schema for class / constructor function.
-Everywhere where a model schema is required as argument, this class / constructor function
-can be passed in as well (for example when using `child` or `ref`.
+Wherever a model schema is required as argument, this class / constructor function
+can be passed in as well (for example when using `object` or `reference`.
 
 When passing an instance of this class to `serialize`, it is not required to pass the model schema
 as first argument anymore, because the default schema will be inferred from the instance type.
@@ -403,10 +405,10 @@ Returns **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 [serializr.js:341-359](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L341-L359 "Source code on GitHub")
 
-Deserializes an json structor into an object graph.
+Deserializes a json structor into an object graph.
 This process might be asynchronous (for example if there are references with an asynchronous
 lookup function). The function returns an object (or array of objects), but the returned object
-might be incomplete until the callback has fired as well (which might happen immediately)
+might be incomplete until the callback has fired as well (which might happen immediately). 
 
 **Parameters**
 
@@ -456,11 +458,11 @@ Returns **PropSchema**
 [serializr.js:613-627](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L613-L627 "Source code on GitHub")
 
 Similar to primitive, but this field will be marked as the identifier for the given Model type.
-This is used by for example `ref()` to serialize the reference
+This is used by for example `reference()` to serialize the reference
 
 Identifier accepts an optional `registerFn` with the signature:
 `(id, target, context) => void`
-that can be used to register this object in some store. note that not all fields of this object might have been deserialized yet
+that can be used to register this object in some store. note that not all fields of this object might have been deserialized yet. 
 
 **Parameters**
 
@@ -555,9 +557,9 @@ Returns **propSchema**
 [serializr.js:738-756](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L738-L756 "Source code on GitHub")
 
 `object` indicates that this property contains an object that needs to be (de)serialized
-using it's own model schema.
+using its own model schema.
 
-N.B. mind issues with circular dependencies when importing model schema's from other files! The module resolve algorithm might expose classes before `createModelSchema` is executed for the target class.
+N.B. mind issues with circular dependencies when importing model schemas from other files! The module resolve algorithm might expose classes before `createModelSchema` is executed for the target class.
 
 **Parameters**
 
@@ -588,13 +590,13 @@ Returns **PropSchema**
 
 [serializr.js:810-843](https://github.com/mobxjs/serializr/blob/b2816013b5db08c83b814ceb437ad35e4592ab8f/serializr.js#L810-L843 "Source code on GitHub")
 
-`reference` can be used to (de)serialize references that points to other models.
+`reference` can be used to (de)serialize references that point to other models.
 
 The first parameter should be either a ModelSchema that has an `identifier()` property (see identifier)
 or a string that represents which attribute in the target object represents the identifier of the object.
 
 The second parameter is a lookup function that is invoked during deserialization to resolve an identifier to
-an object. It's signature should be as follows:
+an object. Its signature should be as follows:
 
 `lookupFunction(identifier, callback, context)` where:
 

--- a/serializr.d.ts
+++ b/serializr.d.ts
@@ -57,6 +57,7 @@ export function child(modelschema: ClazzOrModelSchema<any>): PropSchema;
 export function object(modelschema: ClazzOrModelSchema<any>): PropSchema;
 
 export type RefLookupFunction = (id: string, callback: (err: any, result: any) => void) => void;
+export type RegisterFunction = (id: any, object: any, context: Context) => void;
 
 export function ref(modelschema: ClazzOrModelSchema<any>, lookupFn?: RefLookupFunction): PropSchema;
 export function ref(identifierAttr: string, lookupFn: RefLookupFunction): PropSchema;

--- a/serializr.js
+++ b/serializr.js
@@ -693,7 +693,7 @@
          *     2: { id: 2, title: "test2" }
          * })
          *
-         * @param {function} registerFn optional function to register this object during creation.
+         * @param {RegisterFunction} registerFn optional function to register this object during creation.
          *
          * @returns {PropSchema}
          */
@@ -784,7 +784,7 @@
          *
          * @param {function} serializer function that takes a model value and turns it into a json value
          * @param {function} deserializer function that takes a json value and turns it into a model value
-         * @returns {propSchema}
+         * @returns {PropSchema}
          */
         function custom(serializer, deserializer) {
             invariant(typeof serializer === "function", "first argument should be function")
@@ -891,7 +891,7 @@
          * )
          *
          * @param target: ModelSchema or string
-         * @param {function} lookup function
+         * @param {RefLookupFunction} lookupFn function
          * @returns {PropSchema}
          */
         function reference(target, lookupFn) {

--- a/serializr.js
+++ b/serializr.js
@@ -804,20 +804,24 @@
          * N.B. mind issues with circular dependencies when importing model schema's from other files! The module resolve algorithm might expose classes before `createModelSchema` is executed for the target class.
          *
          * @example
+         *
+         * class SubTask{}
+         * class Todo{}
+         *
          * createModelSchema(SubTask, {
          *   title: true
-         * })
+         * });
          * createModelSchema(Todo, {
-         *   title: true
+         *   title: true,
          *   subTask: object(SubTask)
-         * })
+         * });
          *
          * const todo = deserialize(Todo, {
          *   title: "Task",
          *   subTask: {
          *     title: "Sub task"
          *   }
-         * })
+         * });
          *
          * @param {modelSchema} modelSchema to be used to (de)serialize the child
          * @returns {PropSchema}
@@ -861,13 +865,18 @@
          * N.B. mind issues with circular dependencies when importing model schema's from other files! The module resolve algorithm might expose classes before `createModelSchema` is executed for the target class.
          *
          * @example
+         *
+         *
+         * class User{}
+         * class Post{}
+         *
          * createModelSchema(User, {
          *   uuid: identifier(),
          *   displayname: primitive()
          * })
          *
          * createModelSchema(Post, {
-         *   author: reference(User, findUserById)
+         *   author: reference(User, findUserById),
          *   message: primitive()
          * })
          *
@@ -940,11 +949,16 @@
          * Accepts a sub model schema to serialize the contents
          *
          * @example
+         *
+         * class SubTask{}
+         * class Task{}
+         * class Todo{}
+         *
          * createModelSchema(SubTask, {
          *   title: true
          * })
          * createModelSchema(Todo, {
-         *   title: true
+         *   title: true,
          *   subTask: list(child(SubTask))
          * })
          *

--- a/serializr.js
+++ b/serializr.js
@@ -59,7 +59,50 @@
 /*
  * ## Managing model schemas
  */
-
+        /*
+            JSDOC type defintions for usage w/o typescript.
+            
+            * @typedef {Object} PropSchema
+            * @property {serializerFunction} serializer
+            * @property {deserializerFunction} deserializer
+            * @property {boolean} identifier
+            *
+            * @typedef {Object} PropertyDescriptor
+            * @param {*} value
+            * @param {boolean} writeable
+            * @param {Function|undefined} get
+            * @param {Function|undefined} set
+            * @param {boolean} configurable
+            * @param {boolean} enumerable
+            *
+            * @callback serializerFunction
+            * @param {*} sourcePropertyValue
+            * @returns any - serialized object
+            *
+            *
+            * @callback deserializerFunction
+            * @param {*} jsonValue
+            * @param {cpsCallback} callback
+            * @param {Context} context
+            * @param {*} currentPropertyValue
+            * @returns void
+            *
+            * @callback RegisterFunction
+            * @param {*} id
+            * @param {object} target
+            * @param {Context} context
+            *
+            * @callback cpsCallback
+            * @param {*} result
+            * @param {*} error
+            * @returns void
+            *
+            * @callback RefLookupFunction
+            * @param {string} id
+            * @param {cpsCallback} callback
+            * @returns void
+             */
+        
         /**
          * Creates a model schema that (de)serializes from / to plain javascript objects.
          * It's factory method is: `() => ({})`

--- a/serializr.js
+++ b/serializr.js
@@ -59,49 +59,53 @@
 /*
  * ## Managing model schemas
  */
-        /*
-            JSDOC type defintions for usage w/o typescript.
-            
-            * @typedef {Object} PropSchema
-            * @property {serializerFunction} serializer
-            * @property {deserializerFunction} deserializer
-            * @property {boolean} identifier
-            *
-            * @typedef {Object} PropertyDescriptor
-            * @param {*} value
-            * @param {boolean} writeable
-            * @param {Function|undefined} get
-            * @param {Function|undefined} set
-            * @param {boolean} configurable
-            * @param {boolean} enumerable
-            *
-            * @callback serializerFunction
-            * @param {*} sourcePropertyValue
-            * @returns any - serialized object
-            *
-            *
-            * @callback deserializerFunction
-            * @param {*} jsonValue
-            * @param {cpsCallback} callback
-            * @param {Context} context
-            * @param {*} currentPropertyValue
-            * @returns void
-            *
-            * @callback RegisterFunction
-            * @param {*} id
-            * @param {object} target
-            * @param {Context} context
-            *
-            * @callback cpsCallback
-            * @param {*} result
-            * @param {*} error
-            * @returns void
-            *
-            * @callback RefLookupFunction
-            * @param {string} id
-            * @param {cpsCallback} callback
-            * @returns void
-             */
+        /**
+         * JSDOC type defintions for usage w/o typescript.
+         * @typedef {object} PropSchema
+         * @property {serializerFunction} serializer
+         * @property {deserializerFunction} deserializer
+         * @property {boolean} identifier
+         *
+         * @typedef {object} PropertyDescriptor
+         * @param {*} value
+         * @param {boolean} writeable
+         * @param {Function|undefined} get
+         * @param {Function|undefined} set
+         * @param {boolean} configurable
+         * @param {boolean} enumerable
+         *
+         * @callback serializerFunction
+         * @param {*} sourcePropertyValue
+         * @returns any - serialized object
+         *
+         *
+         * @callback deserializerFunction
+         * @param {*} jsonValue
+         * @param {cpsCallback} callback
+         * @param {Context} context
+         * @param {*} currentPropertyValue
+         * @returns void
+         *
+         * @callback RegisterFunction
+         * @param {*} id
+         * @param {object} target
+         * @param {Context} context
+         *
+         * @callback cpsCallback
+         * @param {*} result
+         * @param {*} error
+         * @returns void
+         *
+         * @callback RefLookupFunction
+         * @param {string} id
+         * @param {cpsCallback} callback
+         * @returns void
+         *
+         * @typedef {object} ModelSchema
+         * @param factory
+         * @param props
+         * @param targetClass
+         */
         
         /**
          * Creates a model schema that (de)serializes from / to plain javascript objects.
@@ -111,7 +115,7 @@
          * var todoSchema = createSimpleSchema({
          *   title: true,
          *   done: true
-         * };
+         * });
          *
          * var json = serialize(todoSchema, { title: "Test", done: false })
          * var todo = deserialize(todoSchema, json)
@@ -147,7 +151,7 @@
          * var json = serialize(new Todo("Test", false))
          * var todo = deserialize(Todo, json)
          *
-         * @param {function} clazz clazz or constructor function
+         * @param {constructor|class} clazz class or constructor function
          * @param {object} props property mapping
          * @param {function} factory optional custom factory. Receives context as first arg
          * @returns {object} model schema
@@ -273,8 +277,8 @@
         /**
          * Returns the standard model schema associated with a class / constructor function
          *
-         * @param {function} clazz class or constructor function
-         * @returns {object} model schema
+         * @param {object} thing
+         * @returns {ModelSchema} model schema
          */
         function getDefaultModelSchema(thing) {
             if (!thing)
@@ -295,8 +299,9 @@
          * When passing an instance of this class to `serialize`, it is not required to pass the model schema
          * as first argument anymore, because the default schema will be inferred from the instance type.
          *
-         * @param {function} clazz class or constructor function
-         * @returns {object} model schema
+         * @param {constructor|class} clazz class or constructor function
+         * @param {ModelSchema} modelSchema - a model schema
+         * @returns {ModelSchema} model schema
          */
         function setDefaultModelSchema(clazz, modelSchema) {
             invariant(isModelSchema(modelSchema))
@@ -418,12 +423,12 @@
          * lookup function). The function returns an object (or array of objects), but the returned object
          * might be incomplete until the callback has fired as well (which might happen immediately)
          *
-         * @param {object or array} modelschema to use for deserialization
+         * @param {object|array} schema to use for deserialization
          * @param {json} json data to deserialize
          * @param {function} callback node style callback that is invoked once the deserializaiton has finished.
          * First argument is the optional error, second argument is the deserialized object (same as the return value)
-         * @param {any} customArgs custom arguments that are available as `context.args` during the deserialization process. This can be used as dependency injection mechanism to pass in, for example, stores.
-         * @returns {object or array} deserialized object, possibly incomplete.
+         * @param {*} customArgs custom arguments that are available as `context.args` during the deserialization process. This can be used as dependency injection mechanism to pass in, for example, stores.
+         * @returns {object|array} deserialized object, possibly incomplete.
          */
         function deserialize(schema, json, callback, customArgs) {
             invariant(arguments.length >= 2, "deserialize expects at least 2 arguments")
@@ -607,7 +612,7 @@
          * @param {object} target target instance to update
          * @param {object} json the json to deserialize
          * @param {function} callback the callback to invoke once deserialization has completed.
-         * @param {any} customArgs custom arguments that are available as `context.args` during the deserialization process. This can be used as dependency injection mechanism to pass in, for example, stores.
+         * @param {*} customArgs custom arguments that are available as `context.args` during the deserialization process. This can be used as dependency injection mechanism to pass in, for example, stores.
          */
         function update(modelSchema, target, json, callback, customArgs) {
             var inferModelSchema =
@@ -648,7 +653,7 @@
          * console.dir(serialize(new Todo("test")))
          * // outputs: { title : "test" }
          *
-         * @returns {PropSchema}
+         * @returns {ModelSchema}
          */
         function primitive() {
             return {
@@ -665,6 +670,8 @@
         }
 
         /**
+         *
+         *
          * Similar to primitive, but this field will be marked as the identifier for the given Model type.
          * This is used by for example `reference()` to serialize the reference
          *
@@ -693,6 +700,7 @@
          *     1: { id: 1, title: "test1" },
          *     2: { id: 2, title: "test2" }
          * })
+         *
          *
          * @param {RegisterFunction} registerFn optional function to register this object during creation.
          *
@@ -753,7 +761,7 @@
          * console.dir(serialize(new Todo("test")))
          * // { task : "test" }
          *
-         * @param {string} alias name of the json field to be used for this property
+         * @param {string} name name of the json field to be used for this property
          * @param {PropSchema} propSchema propSchema to (de)serialize the contents of this field
          * @returns {PropSchema}
          */
@@ -824,7 +832,7 @@
          *   }
          * });
          *
-         * @param {modelSchema} modelSchema to be used to (de)serialize the object
+         * @param {ModelSchema} modelSchema to be used to (de)serialize the object
          * @returns {PropSchema}
          */
         function object(modelSchema) {
@@ -1006,7 +1014,7 @@
          * This can be both plain objects (default) or ES6 Map like structures.
          * This will be inferred from the initial value of the targetted attribute.
          *
-         * @param {any} propSchema
+         * @param {*} propSchema
          * @returns
          */
         function map(propSchema) {

--- a/serializr.js
+++ b/serializr.js
@@ -105,7 +105,7 @@
         
         /**
          * Creates a model schema that (de)serializes from / to plain javascript objects.
-         * It's factory method is: `() => ({})`
+         * Its factory method is: `() => ({})`
          *
          * @example
          * var todoSchema = createSimpleSchema({
@@ -131,7 +131,7 @@
         /**
          * Creates a model schema that (de)serializes an object created by a constructor function (class).
          * The created model schema is associated by the targeted type as default model schema, see setDefaultModelSchema.
-         * It's factory method is `() => new clazz()` (unless overriden, see third arg).
+         * Its factory method is `() => new clazz()` (unless overriden, see third arg).
          *
          * @example
          * function Todo(title, done) {
@@ -290,7 +290,7 @@
         /**
          * Sets the default model schema for class / constructor function.
          * Everywhere where a model schema is required as argument, this class / constructor function
-         * can be passed in as well (for example when using `child` or `ref`.
+         * can be passed in as well (for example when using `object` or `ref`.
          *
          * When passing an instance of this class to `serialize`, it is not required to pass the model schema
          * as first argument anymore, because the default schema will be inferred from the instance type.
@@ -413,7 +413,7 @@
  */
 
         /**
-         * Deserializes an json structor into an object graph.
+         * Deserializes a json structor into an object graph.
          * This process might be asynchronous (for example if there are references with an asynchronous
          * lookup function). The function returns an object (or array of objects), but the returned object
          * might be incomplete until the callback has fired as well (which might happen immediately)
@@ -666,11 +666,12 @@
 
         /**
          * Similar to primitive, but this field will be marked as the identifier for the given Model type.
-         * This is used by for example `ref()` to serialize the reference
+         * This is used by for example `reference()` to serialize the reference
          *
          * Identifier accepts an optional `registerFn` with the signature:
          * `(id, target, context) => void`
-         * that can be used to register this object in some store. note that not all fields of this object might have been deserialized yet
+         * that can be used to register this object in some store. note that not all fields of this object might
+         * have been deserialized yet.
          *
          * @example
          * var todos = {};
@@ -799,7 +800,7 @@
 
         /**
          * `object` indicates that this property contains an object that needs to be (de)serialized
-         * using it's own model schema.
+         * using its own model schema.
          *
          * N.B. mind issues with circular dependencies when importing model schema's from other files! The module resolve algorithm might expose classes before `createModelSchema` is executed for the target class.
          *
@@ -823,7 +824,7 @@
          *   }
          * });
          *
-         * @param {modelSchema} modelSchema to be used to (de)serialize the child
+         * @param {modelSchema} modelSchema to be used to (de)serialize the object
          * @returns {PropSchema}
          */
         function object(modelSchema) {
@@ -847,13 +848,13 @@
         }
 
         /**
-         * `reference` can be used to (de)serialize references that points to other models.
+         * `reference` can be used to (de)serialize references that point to other models.
          *
          * The first parameter should be either a ModelSchema that has an `identifier()` property (see identifier)
          * or a string that represents which attribute in the target object represents the identifier of the object.
          *
          * The second parameter is a lookup function that is invoked during deserialization to resolve an identifier to
-         * an object. It's signature should be as follows:
+         * an object. Its signature should be as follows:
          *
          * `lookupFunction(identifier, callback, context)` where:
          * 1. `identifier` is the identifier being resolved
@@ -862,7 +863,7 @@
          *
          * The lookupFunction is optional. If it is not provided, it will try to find an object of the expected type and required identifier within the same JSON document
          *
-         * N.B. mind issues with circular dependencies when importing model schema's from other files! The module resolve algorithm might expose classes before `createModelSchema` is executed for the target class.
+         * N.B. mind issues with circular dependencies when importing model schemas from other files! The module resolve algorithm might expose classes before `createModelSchema` is executed for the target class.
          *
          * @example
          *
@@ -959,7 +960,7 @@
          * })
          * createModelSchema(Todo, {
          *   title: true,
-         *   subTask: list(child(SubTask))
+         *   subTask: list(object(SubTask))
          * })
          *
          * const todo = deserialize(Todo, {

--- a/serializr.js
+++ b/serializr.js
@@ -321,7 +321,7 @@
 
         function getIdentifierProp(modelSchema) {
             invariant(isModelSchema(modelSchema))
-            // optimizatoin: cache this lookup
+            // optimization: cache this lookup
             while (modelSchema) {
                 for (var propName in modelSchema.props)
                     if (typeof modelSchema.props[propName] === "object" && modelSchema.props[propName].identifier === true)


### PR DESCRIPTION
My general aim was to make all the code examples in the README file into valid javascript. 

I also wanted to make the longer form code examples that weren't part of document-gem (e.g. the quick start and the putting it all together), into something that could be executed directly w/o having to write any additional code. I tried my best to keep the 'spirit' of the code but if i erred in that, please tell me.


Additionally:

1. I added typedefs to the JSDoc so (a) it'll work with IDEs that don't understand typescript typings; and when DocumentationJS is fixed to print out typedefs as well; it'll automatically add them to the documentation with proper linking.

2. Lastly, I removed any reference in the examples to deprecated functions like ref() / child(). 

3. I expanded on the spelling corrections in patch #15; and made changes in the code-comments to support this.

Hope this helps. If you only want to use some of this, I can parcel that into a digestible chunk.