### PR TITLE
[typings] deserialize typings for usage with arrays of objects

### DIFF
--- a/serializr.d.ts
+++ b/serializr.d.ts
@@ -40,6 +40,7 @@ export function setDefaultModelSchema<T>(clazz: Clazz<T>, modelschema: ModelSche
 export function serialize<T>(modelschema: ClazzOrModelSchema<T>, instance: T): any;
 export function serialize<T>(instance: T): any;
 
+export function deserialize<T>(modelschema: ClazzOrModelSchema<T>, jsonArray: any[], callback?: (err: any, result: T[]) => void, customArgs?: any): T[];
 export function deserialize<T>(modelschema: ClazzOrModelSchema<T>, json: any, callback?: (err: any, result: T) => void, customArgs?: any): T;
 
 export function update<T>(modelschema: ClazzOrModelSchema<T>, instance:T, json: any, callback?: (err: any, result: T) => void, customArgs?: any): void;


### PR DESCRIPTION
Previously with TypeScript using deserialize on arrays required forcing compiler to cast return type from `T` to `T[]`, since there was no declaration for arrays.

After change if compiler knows that json passed to deserialize is an array, it will assume that returned value is an array as well.

Should not break previous code (uses of deserialize with single object). unless in rare (if even possible?) case that user wanted convert array to single value, and made sure compiler knows that json is an array.