### PR TITLE
Add dynamicObject property decorator

### DIFF
--- a/serializr.d.ts
+++ b/serializr.d.ts
@@ -56,6 +56,7 @@ export function alias(jsonName: string, propSchema?: PropSchema | boolean): Prop
 
 export function child(modelschema: ClazzOrModelSchema<any>): PropSchema;
 export function object(modelschema: ClazzOrModelSchema<any>): PropSchema;
+export function dynamicObject(modelschemas: ClazzOrModelSchema<any>[]): PropSchema;
 
 export type RefLookupFunction = (id: string, callback: (err: any, result: any) => void) => void;
 export type RegisterFunction = (id: any, object: any, context: Context) => void;


### PR DESCRIPTION
For a project where I'm using Serializr (which is awesome btw!), I need to be able to (de)serialize properties that hold objects which can be of different types, i.e. have different model schema's. This PR adds support for that.

It's basically a copy of the object(modelschema) decorator, but instead of a fixed model schema, it requires an array of possible model schema's. During serialization, the decorator will detect the actual model schema, use it to serialize the object, and also save the name to the Json, to be able to deserialize the object back to the same type.
I think it's especially useful in a TypeScript project where you might want to serialize properties that are of type interface.

Improvements:
- Detect the actual model schema in a smarter way. I don't really like to have to tell the decorator all the types of which the object might be. But I'm not sure on how to proceed... was thinking about introducing another decorator that you have to put on the deriving class, saying it is an implementation/extension for type x, and store that in the context or something...?
- Write tests

