### PR TITLE
Skip serialization / deserialization 

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ Can be used to create simple custom propSchema.
 -   `serializer` **[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** function that takes a model value and turns it into a json value
 -   `deserializer` **[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** function that takes a json value and turns it into a model value
 
-If either the `serializer` or `deserializer` return `undefined` or do not return a value will be skipped.  Serializers that want to blank a property should explicitly return null.
+The `serializer` or `deserializer` functions may return `SKIP` to indicate that the property should not be used.  This can be usefull for objects who's state affects whether they should be saved or updated.
 
 **Examples**
 
@@ -594,9 +594,13 @@ var schema = _.createSimpleSchema({
     function(v) { return v + 2 },
     function(v) { return v - 2 }
   )
+  b: _.custom(_.custom(
+    function(v) { return v },
+    function(v) { return v === 'INVALID' ? _.SKIP : v }
+  )
 })
-t.deepEqual(_.serialize(s, { a: 4 }), { a: 6 })
-t.deepEqual(_.deserialize(s, { a: 6 }), { a: 4 })
+t.deepEqual(_.serialize(s, { a: 4, b: 'INVALID' }), { a: 6, b: 'INVALID' })
+t.deepEqual(_.deserialize(s, { a: 6 }), { a: 4 }) // no "b" is included because it's 'INVALID'
 ```
 
 Returns **PropSchema** 

--- a/README.md
+++ b/README.md
@@ -584,6 +584,8 @@ Can be used to create simple custom propSchema.
 -   `serializer` **[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** function that takes a model value and turns it into a json value
 -   `deserializer` **[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** function that takes a json value and turns it into a model value
 
+If either the `serializer` or `deserializer` return `undefined` or do not return a value will be skipped.  Serializers that want to blank a property should explicitly return null.
+
 **Examples**
 
 ```javascript

--- a/serializr.js
+++ b/serializr.js
@@ -1,7 +1,9 @@
 (function(g) {
     "use strict"
-
+    
     function mrFactory() {
+        // Indicate properties should be skipped
+        var SKIP = Symbol('SKIP')
 /*
  * Generic utility functions
  */
@@ -403,7 +405,7 @@
                 if (propDef === false)
                     return
                 var jsonValue = propDef.serializer(obj[key])
-                if (jsonValue === undefined){
+                if (jsonValue === SKIP){
                     return
                 }
                 res[propDef.jsonname || key] = jsonValue
@@ -494,7 +496,7 @@
                     // this allows props to complete after completing the object itself
                     // enabling reference resolving and such
                     context.rootContext.createCallback(function (value) {
-                        if (value !== undefined){
+                        if (value !== SKIP){
                             target[propName] = value
                         }
                     }),
@@ -1098,7 +1100,8 @@
             child: object, // deprecate
             reference: reference,
             ref: reference, // deprecate
-            custom: custom
+            custom: custom,
+            SKIP: SKIP
         }
     }
 

--- a/serializr.js
+++ b/serializr.js
@@ -403,6 +403,9 @@
                 if (propDef === false)
                     return
                 var jsonValue = propDef.serializer(obj[key])
+                if (jsonValue === undefined){
+                    return
+                }
                 res[propDef.jsonname || key] = jsonValue
             })
             return res
@@ -491,7 +494,9 @@
                     // this allows props to complete after completing the object itself
                     // enabling reference resolving and such
                     context.rootContext.createCallback(function (value) {
-                        target[propName] = value
+                        if (value !== undefined){
+                            target[propName] = value
+                        }
                     }),
                     context,
                     target[propName] // initial value

--- a/serializr.js
+++ b/serializr.js
@@ -404,7 +404,7 @@
                     propDef = _defaultPrimitiveProp
                 if (propDef === false)
                     return
-                var jsonValue = propDef.serializer(obj[key])
+                var jsonValue = propDef.serializer(obj[key], key, obj)
                 if (jsonValue === SKIP){
                     return
                 }

--- a/test/simple.js
+++ b/test/simple.js
@@ -109,24 +109,26 @@ test("it should respect custom schemas", t => {
     t.end()
 })
 
-test("it should not set values for custom serializers/deserializer that return undefined", t => {
+test("it should not set values for custom serializers/deserializer that return SKIP", t => {
+    t.equal(typeof _.SKIP, 'symbol')
     var s = _.createSimpleSchema({
         a: _.custom(
             function(v) { return v },
-            function(v) { return undefined }
+            function(v) { return _.SKIP }
         )
     })
+
     t.deepEqual(_.serialize(s, { a: 4 }), { a: 4 })
     t.deepEqual(_.deserialize(s, { a: 4 }), { })
 
     s = _.createSimpleSchema({
         a: _.custom(
-            function(v) { return undefined },
-            function(v) { return null }
+            function(v) { return _.SKIP },
+            function(v) { return undefined }
         )
     })
     t.deepEqual(_.serialize(s, { a: 4 }), { })
-    t.deepEqual(_.deserialize(s, { a: 4 }), { a: null })
+    t.deepEqual(_.deserialize(s, { a: 4 }), { a: undefined })
 
     t.end()
 })

--- a/test/simple.js
+++ b/test/simple.js
@@ -109,6 +109,28 @@ test("it should respect custom schemas", t => {
     t.end()
 })
 
+test("it should not set values for custom serializers/deserializer that return undefined", t => {
+    var s = _.createSimpleSchema({
+        a: _.custom(
+            function(v) { return v },
+            function(v) { return undefined }
+        )
+    })
+    t.deepEqual(_.serialize(s, { a: 4 }), { a: 4 })
+    t.deepEqual(_.deserialize(s, { a: 4 }), { })
+
+    s = _.createSimpleSchema({
+        a: _.custom(
+            function(v) { return undefined },
+            function(v) { return null }
+        )
+    })
+    t.deepEqual(_.serialize(s, { a: 4 }), { })
+    t.deepEqual(_.deserialize(s, { a: 4 }), { a: null })
+
+    t.end()
+})
+
 test("it should respect extends", t => {
     var superSchema = _.createSimpleSchema({
         x: primitive()

--- a/test/simple.js
+++ b/test/simple.js
@@ -133,6 +133,19 @@ test("it should not set values for custom serializers/deserializer that return S
     t.end()
 })
 
+test("it should pass key and object to custom schemas", t => {
+    var s = _.createSimpleSchema({
+        a: primitive(),
+        b: _.custom(
+            function(v, k, obj) { return k + String(v * obj.b) },
+            function(v) { return v }
+        )
+    })
+    t.deepEqual(_.serialize(s, { a: 2, b: 4 }), { a: 2, b: 'b16' })
+    t.deepEqual(_.deserialize(s, { a: 6, b: 2 }), { a: 6, b: 2 })
+    t.end()
+})
+
 test("it should respect extends", t => {
     var superSchema = _.createSimpleSchema({
         x: primitive()


### PR DESCRIPTION
This allows custom serializers/deserializers to conditionally skip setting properties.

My use case for this is that I'm migrating a large app that used [ampersand-state](https://github.com/AmpersandJS/ampersand-state) to Mobx and Serializr.

As part of the migration I've extracted some decorators I found useful to [mobx-decorated-models](https://github.com/nathanstitt/mobx-decorated-models).  It's a bunch of decorators that make using Serializr with Mobx a bit easier for my use case.  However `ampersand-state` has the concept of `session` attributes, which are fields that behave just like other attributes in that they can be optionally set from the server, but are not serialized for saving.

They're pretty useful for allowing the server to send pre-computed values for things that are difficult/impossible to generate client-side.  But it makes no sense for the client to save the values back to the server.

This change will allow me to support that type of functionality.  I'm happy to rework in a different fashion if you think something else would be a better way to support this.
