### PR TITLE
Fix "Class constructor cannot be invoked without 'new'" bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "npm run build-test && node test/index",
     "lint": "eslint serializr.js",
     "prepublish": "npm run small-build && npm run build-docs",
-    "small-build": "uglifyjs -m sort,toplevel -c --screw-ie8 --preamble '/** serializr - (c) Michel Weststrate 2016 - MIT Licensed */' --source-map serializr.min.js.map -o serializr.min.js serializr.js",
+    "small-build": "uglifyjs -m sort,toplevel -c --screw-ie8 --preamble \"/** serializr - (c) Michel Weststrate 2016 - MIT Licensed */\" --source-map serializr.min.js.map -o serializr.min.js serializr.js",
     "build-docs": "documentation readme serializr.js --github --section API",
     "build-test": "npm run build-test-babel && npm run build-test-ts",
     "build-test-ts": "tsc -p test/typescript",

--- a/serializr.js
+++ b/serializr.js
@@ -246,11 +246,7 @@
                     descriptor = undefined
                     target = target.prototype
                     // Create a factory so the constructor is called properly
-                    factory = function(context) {
-                        function F(args) {
-                            return target.constructor.apply(this, args)
-                        }
-                        F.prototype = target.constructor.prototype
+                     factory = function(context) {
                         var params = []
                         for (var i = 0; i < target.constructor.length; i++) {
                           Object.keys(context.modelSchema.props).forEach(function (key) {
@@ -260,7 +256,8 @@
                             }
                           });
                         }
-                        return new F(params)
+                        
+                        return new (Function.prototype.bind.apply(target.constructor, [null].concat(params)));
                     }
                 }
             }

--- a/test/typescript/ts.ts
+++ b/test/typescript/ts.ts
@@ -71,6 +71,22 @@ test("typescript class with constructor params", t => {
     t.end();
 });
 
+test("typescript class with only constructor params", t => {
+    class Rectangle {
+      constructor(@serializable(alias("identifier", identifier())) public id: string, @serializable(alias("width", true)) public width: number, @serializable(alias("height", true)) public height: number) { }
+    }
+
+    const a = new Rectangle("A", 10, 20);
+
+    let json = serialize(a);
+    const b = deserialize(Rectangle, json);
+    t.equal(a.id, b.id);
+    t.equal(a.width, b.width);
+    t.equal(a.height, b.height);
+
+    t.end();
+});
+
 test("[ts] it should handle prototypes", t => {
     class A {
         @serializable a = "hoi";

--- a/test/typescript/tsconfig.json
+++ b/test/typescript/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "version": "1.7.5",
     "compilerOptions": {
-        "target": "es5",
+        "target": "es2015",
         "sourceMap": false,
         "module": "commonjs",
         "removeComments": false,


### PR DESCRIPTION
Was having issue where "Class constructor cannot be invoked without 'new'" was getting thrown when calling "serialize" on my TypeScript class. I was able to reproduce this with a class that only had constructor parameters, added a test with this condition. Not sure why these cases are treated differently by V8 (Node and Chrome both have the problem, Firefox doesn't seem to) but this PR fixes the issue by changing how the "serializable" factory works slightly.