### PR TITLE
[Feature] context for serialization

### DIFF
--- a/src/core/BaseContext.js
+++ b/src/core/BaseContext.js
@@ -3,17 +3,32 @@ import { GUARDED_NOOP } from "../utils/utils";
 
 export function BaseContext(parentContext, onReadyCb) {
     this.parentContext = parentContext
+    this.onFinishCallbacks = [];
     this.onReadyCb = onReadyCb || GUARDED_NOOP;
     this.error = undefined;
     this.rootContext = this.parentContext && this.parentContext.rootContext || this;
     this.isRoot = !this.parentContext;
 }
 
+BaseContext.prototype.addCallback = function addCallback(listenerFunction) {
+    if (typeof listenerFunction === "function") {
+        this.onFinishCallbacks = this.onFinishCallbacks || [];
+        this.onFinishCallbacks.push(listenerFunction);
+    }
+};
+
 BaseContext.prototype.setError = function setError(newError) {
     this.error = newError;
 };
 
 BaseContext.prototype.finished = function finished(data) {
+    if (this.onFinishCallbacks && Array.isArray(this.onFinishCallbacks) && this.onFinishCallbacks.length > 0) {
+        this.onFinishCallbacks.forEach(function (listener) {
+            if (typeof listener === "function") {
+                listener(this.error);
+            }
+        })
+    }
     if (typeof this.onReadyCb === "function") {
         if (this.error) {
             this.onReadyCb(this.error);

--- a/src/core/BaseContext.js
+++ b/src/core/BaseContext.js
@@ -1,0 +1,24 @@
+
+import { GUARDED_NOOP } from "../utils/utils";
+
+export function BaseContext(parentContext, onReadyCb) {
+    this.parentContext = parentContext
+    this.onReadyCb = onReadyCb || GUARDED_NOOP;
+    this.error = undefined;
+    this.rootContext = this.parentContext && this.parentContext.rootContext || this;
+    this.isRoot = !this.parentContext;
+}
+
+BaseContext.prototype.setError = function setError(newError) {
+    this.error = newError;
+};
+
+BaseContext.prototype.finished = function finished(data) {
+    if (typeof this.onReadyCb === "function") {
+        if (this.error) {
+            this.onReadyCb(this.error);
+        } else {
+            this.onReadyCb(undefined, data);
+        }
+    }
+}

--- a/src/core/SerializeContext.js
+++ b/src/core/SerializeContext.js
@@ -1,0 +1,8 @@
+import { BaseContext } from "./BaseContext";
+
+export default function SerializeContext(parentContext, modelSchema, json, onReadyCb, customArgs) {
+    BaseContext.call(this, parentContext, onReadyCb);
+
+}
+
+SerializeContext.prototype = new BaseContext();

--- a/src/types/custom.js
+++ b/src/types/custom.js
@@ -29,7 +29,7 @@ import { invariant } from "../utils/utils"
  * t.deepEqual(_.serialize(s, { a: 4 }), { a: 6 });
  * t.deepEqual(_.deserialize(s, { a: 6 }), { a: 4 });
  *
- * @param {function} serializer function that takes a model value and turns it into a json value
+ * @param {function} serializer function that takes a model value and turns it into a json value. It also takes context argument, which can allow you to add a global callback to the ending of serialization.
  * @param {function} deserializer function that takes a json value and turns it into a model value. It also takes context argument, which can allow you to deserialize based on the context of other parameters.
  * @returns {PropSchema}
  */

--- a/src/types/list.js
+++ b/src/types/list.js
@@ -35,9 +35,9 @@ export default function list(propSchema) {
     invariant(isPropSchema(propSchema), "expected prop schema as first argument")
     invariant(!isAliasedPropSchema(propSchema), "provided prop is aliased, please put aliases first")
     return {
-        serializer: function (ar, key, target) {
+        serializer: function (ar, key, target, context) {
             invariant(ar && "length" in ar && "map" in ar, "expected array (like) object")
-            return ar.map(function (item, index) { return propSchema.serializer(item, index, ar) })
+            return ar.map(function (item, index) { return propSchema.serializer(item, index, ar, context) })
         },
         deserializer: function(jsonArray, done, context) {
             if (!Array.isArray(jsonArray))

--- a/src/types/list.js
+++ b/src/types/list.js
@@ -35,9 +35,9 @@ export default function list(propSchema) {
     invariant(isPropSchema(propSchema), "expected prop schema as first argument")
     invariant(!isAliasedPropSchema(propSchema), "provided prop is aliased, please put aliases first")
     return {
-        serializer: function (ar) {
+        serializer: function (ar, key, target) {
             invariant(ar && "length" in ar && "map" in ar, "expected array (like) object")
-            return ar.map(propSchema.serializer)
+            return ar.map(function (item, index) { return propSchema.serializer(item, index, ar) })
         },
         deserializer: function(jsonArray, done, context) {
             if (!Array.isArray(jsonArray))

--- a/src/types/map.js
+++ b/src/types/map.js
@@ -15,16 +15,16 @@ export default function map(propSchema) {
     invariant(isPropSchema(propSchema), "expected prop schema as first argument")
     invariant(!isAliasedPropSchema(propSchema), "provided prop is aliased, please put aliases first")
     return {
-        serializer: function (m, k, target) {
+        serializer: function (m, k, target, context) {
             invariant(m && typeof m === "object", "expected object or Map")
             var isMap = isMapLike(m)
             var result = {}
             if (isMap)
                 m.forEach(function(value, key) {
-                    result[key] = propSchema.serializer(value, key, m)
+                    result[key] = propSchema.serializer(value, key, m, context)
                 })
             else for (var key in m)
-                result[key] = propSchema.serializer(m[key], key, m)
+                result[key] = propSchema.serializer(m[key], key, m, context)
             return result
         },
         deserializer: function(jsonObject, done, context, oldValue) {

--- a/src/types/map.js
+++ b/src/types/map.js
@@ -15,16 +15,16 @@ export default function map(propSchema) {
     invariant(isPropSchema(propSchema), "expected prop schema as first argument")
     invariant(!isAliasedPropSchema(propSchema), "provided prop is aliased, please put aliases first")
     return {
-        serializer: function (m) {
+        serializer: function (m, k, target) {
             invariant(m && typeof m === "object", "expected object or Map")
             var isMap = isMapLike(m)
             var result = {}
             if (isMap)
                 m.forEach(function(value, key) {
-                    result[key] = propSchema.serializer(value)
+                    result[key] = propSchema.serializer(value, key, m)
                 })
             else for (var key in m)
-                result[key] = propSchema.serializer(m[key])
+                result[key] = propSchema.serializer(m[key], key, m)
             return result
         },
         deserializer: function(jsonObject, done, context, oldValue) {

--- a/src/types/mapAsArray.js
+++ b/src/types/mapAsArray.js
@@ -17,11 +17,11 @@ export default function mapAsArray(propSchema, keyPropertyName) {
     invariant(isPropSchema(propSchema), "expected prop schema as first argument")
     invariant(!!keyPropertyName, "expected key property name as second argument")
     return {
-        serializer: function (m) {
+        serializer: function (m, k, target) {
             var result = []
             // eslint-disable-next-line no-unused-vars
             m.forEach(function (value, key) {
-                result.push(propSchema.serializer(value))
+                result.push(propSchema.serializer(value, key, m))
             })
             return result
         },

--- a/src/types/mapAsArray.js
+++ b/src/types/mapAsArray.js
@@ -17,11 +17,11 @@ export default function mapAsArray(propSchema, keyPropertyName) {
     invariant(isPropSchema(propSchema), "expected prop schema as first argument")
     invariant(!!keyPropertyName, "expected key property name as second argument")
     return {
-        serializer: function (m, k, target) {
+        serializer: function (m, k, target, context) {
             var result = []
             // eslint-disable-next-line no-unused-vars
             m.forEach(function (value, key) {
-                result.push(propSchema.serializer(value, key, m))
+                result.push(propSchema.serializer(value, key, m, context))
             })
             return result
         },

--- a/src/types/object.js
+++ b/src/types/object.js
@@ -34,12 +34,12 @@ import { deserializeObjectWithSchema } from "../core/deserialize"
 export default function object(modelSchema) {
     invariant(typeof modelSchema === "object" || typeof modelSchema === "function", "No modelschema provided. If you are importing it from another file be aware of circular dependencies.")
     return {
-        serializer: function (item, key, target) {
+        serializer: function (item, key, target, context) {
             modelSchema = getDefaultModelSchema(modelSchema)
             invariant(isModelSchema(modelSchema), "expected modelSchema, got " + modelSchema)
             if (item === null || item === undefined)
                 return item
-            return serialize(modelSchema, item)
+            return serialize(modelSchema, item, context)
         },
         deserializer: function (childJson, done, context) {
             modelSchema = getDefaultModelSchema(modelSchema)

--- a/src/types/object.js
+++ b/src/types/object.js
@@ -34,7 +34,7 @@ import { deserializeObjectWithSchema } from "../core/deserialize"
 export default function object(modelSchema) {
     invariant(typeof modelSchema === "object" || typeof modelSchema === "function", "No modelschema provided. If you are importing it from another file be aware of circular dependencies.")
     return {
-        serializer: function (item) {
+        serializer: function (item, key, target) {
             modelSchema = getDefaultModelSchema(modelSchema)
             invariant(isModelSchema(modelSchema), "expected modelSchema, got " + modelSchema)
             if (item === null || item === undefined)

--- a/test/simple.js
+++ b/test/simple.js
@@ -158,6 +158,23 @@ test("it should pass context to custom schemas", t => {
     t.end()
 })
 
+test("it should pass context to custom schemas and provide an internal callback with serialization", t => {
+    var callbackWasCalled = false;
+    var s = _.createSimpleSchema({
+        a: _.custom(
+            function(v, k, obj, context) {
+                context.rootContext.addCallback(function () {callbackWasCalled = true})
+                return v + 2
+            },
+            function(v) { return v - 2 }
+        )
+    })
+    t.deepEqual(_.serialize(s, { a: 4 }), { a: 6 })
+    t.equal(callbackWasCalled, true, "internal serialization callback was not called")
+    t.deepEqual(_.deserialize(s, { a: 6 }), { a: 4 })
+    t.end()
+})
+
 test("it should respect extends", t => {
     var superSchema = _.createSimpleSchema({
         x: primitive()


### PR DESCRIPTION
deserialization uses a `Context` with all deserializers. Custom serializers become more flexible if the serialization process uses the same mechanism.

## purpose

support automatic creation of references with a custom serializer.

## explanation

A context can be used as a place to store temporary data for serialization. A custom serializer can make use of this temporary data to keep track on all serialized objects and serialize only IDs for those, that have already been serialized. Of course, the companion custom deserializer need to know about such IDs, decode them and behave much like the deserializer of `reference()`.

All this would be impossible without keeping track on all already serialized entities.

