### PR TITLE
feat: made `invariant` be able to output json / object more readable

### DIFF
--- a/src/utils/invariant.js
+++ b/src/utils/invariant.js
@@ -1,0 +1,38 @@
+var formatters = {
+    j: function json(v) {
+        try {
+            return JSON.stringify(v)
+        } catch (error) {
+            return "[UnexpectedJSONParseError]: " + error.message
+        }
+    }
+}
+
+export default function invariant(condition, message) {
+    if (!condition) {
+        var variables = Array.prototype.slice.call(arguments, 2)
+        var variablesToLog = []
+
+        var index = 0
+        var formattedMessage = message.replace(/%([a-zA-Z%])/g, function messageFormatter(match, format) {
+            if (match === "%%") return match
+
+            var formatter = formatters[format]
+
+            if (typeof formatter === "function") {
+                var variable = variables[index++]
+
+                variablesToLog.push(variable)
+
+                return formatter(variable)
+            }
+
+            return match
+        })
+
+        // eslint-disable-next-line no-console
+        console.log.apply(console, variablesToLog)
+
+        throw new Error("[serializr] " + (formattedMessage || "Illegal State"))
+    }
+}

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,3 +1,5 @@
+import invariant from "./invariant"
+
 export function GUARDED_NOOP(err) {
     if (err) // unguarded error...
         throw new Error(err)
@@ -12,11 +14,6 @@ export function once(fn) {
         }
         invariant(false, "callback was invoked twice")
     }
-}
-
-export function invariant(cond, message) {
-    if (!cond)
-        throw new Error("[serializr] " + (message || "Illegal State"))
 }
 
 export function parallel(ar, processor, cb) {
@@ -89,3 +86,5 @@ export function getIdentifierProp(modelSchema) {
     }
     return null
 }
+
+export { invariant }


### PR DESCRIPTION
(#62)

I refer to the implementation of [debug](https://github.com/visionmedia/debug/blob/master/src/common.js#L98).

In addition to stringifying json data, it also output the non-string objects to console by `console.log()`. It's useful that if we want to inspect a complicated object that contains many hidden properties (e.g. observable in mobx) while `update` / `deserialize` failed particularly.

The final effect like below:

![image](https://user-images.githubusercontent.com/10795207/33373044-20b3df2a-d53b-11e7-8b64-88f8dce5694b.png)
