### PR TITLE
Date fix for Safari

### DIFF
--- a/src/types/date.js
+++ b/src/types/date.js
@@ -17,7 +17,8 @@ export default function date() {
         deserializer: function (jsonValue, done) {
             if (jsonValue === null || jsonValue === undefined)
                 return void done(null, jsonValue)
-            return void done(null, new Date(jsonValue))
+            var dateArray = jsonValue.split(/[^0-9]/)
+            return void done(null, new Date (dateArray[0], dateArray[1] - 1, dateArray[2], dateArray[3], dateArray[4], dateArray[5]))
         }
     }
 }

--- a/src/types/date.js
+++ b/src/types/date.js
@@ -17,8 +17,15 @@ export default function date() {
         deserializer: function (jsonValue, done) {
             if (jsonValue === null || jsonValue === undefined)
                 return void done(null, jsonValue)
-            var dateArray = jsonValue.split(/[^0-9]/)
-            return void done(null, new Date (dateArray[0], dateArray[1] - 1, dateArray[2], dateArray[3], dateArray[4], dateArray[5]))
+            var date;
+            if(typeof jsonValue === "string") {
+                var dateArray = jsonValue.split(/[^0-9]/)
+                date = new Date(dateArray[0], dateArray[1] - 1, dateArray[2], dateArray[3], dateArray[4], dateArray[5])
+            }
+            else {
+                date = new Date(jsonValue)
+            }
+            return void done(null, date)
         }
     }
 }


### PR DESCRIPTION
There's a known behavior in Safari that applies current OS time zone to the date object when the Date constructor (or Date.parse method) is used. Because of this serializr will produce the date of 2017/12/07 in New Zealand time zone for the value of '2017-12-06T15:37:39.903'. The suggested fix will mitigate the issue for ISO 8601 format date strings without timezones.

See the following links for more details:
https://stackoverflow.com/a/33909265
https://stackoverflow.com/a/6427318

@mweststrate 