### PR TITLE
Fix for date deserialization in Safari

### DIFF
--- a/src/types/date.js
+++ b/src/types/date.js
@@ -17,7 +17,14 @@ export default function date() {
         deserializer: function (jsonValue, done) {
             if (jsonValue === null || jsonValue === undefined)
                 return void done(null, jsonValue)
-            return void done(null, new Date(jsonValue))
+            var newDate
+            if (typeof jsonValue === "string") {
+                var dateArr = jsonValue.split(/[^0-9]/)
+                newDate = new Date(+dateArr[0], +dateArr[1] - 1, +dateArr[2], +dateArr[3], +dateArr[4], +dateArr[5], +dateArr[6])
+            } else {
+                newDate = new Date(jsonValue)
+            }
+            return void done(null, newDate)
         }
     }
 }

--- a/test/simple.js
+++ b/test/simple.js
@@ -368,3 +368,23 @@ test("it should support dates", t => {
 
     t.end()
 })
+
+test("it should support date strings", t => {
+    var s = _.createSimpleSchema({
+        d: _.date()
+    })
+
+    var a = _.deserialize(s, {
+        d: "2017-12-06T15:37:39.903"
+    })
+    t.ok(a.d instanceof Date)
+    // Months are zero indexed in js
+    var expectedDate = new Date(2017, 11, 6, 15, 37, 39, 903)
+    t.equal(a.d.getTime(), expectedDate.getTime())
+
+    t.deepEqual(_.serialize(s, a), {
+        d: expectedDate.getTime()
+    })
+
+    t.end()
+})


### PR DESCRIPTION
There's a known behavior in Safari that applies current OS time zone to the date object when the Date constructor (or Date.parse method) is used. Because of this serializr will produce the date of 2017/12/07 in New Zealand time zone for the value of '2017-12-06T15:37:39.903'. The suggested fix will mitigate the issue for ISO 8601 format date strings without timezones.

See the following link for more details:
https://stackoverflow.com/a/33909265

@mweststrate 
