### PR TITLE
make beforeDeserialize, afterDeserialize optional

### DIFF
--- a/serializr.d.ts
+++ b/serializr.d.ts
@@ -20,8 +20,8 @@ export interface AdditionalPropArgs {
 export interface PropSchema {
     serializer(sourcePropertyValue: any): any;
     deserializer(jsonValue: any, callback: (err: any, targetPropertyValue: any) => void, context: Context, currentPropertyValue: any): void;
-    beforeDeserialize: BeforeDeserializeFunc;
-    afterDeserialize: AfterDeserializeFunc;
+    beforeDeserialize?: BeforeDeserializeFunc;
+    afterDeserialize?: AfterDeserializeFunc;
 }
 
 export type Props = {


### PR DESCRIPTION
These aren't required when writing custom serializers.   This fixes the d.ts to match. 