### PR TITLE
Allow serializing plain objects by specifying constructor.

### DIFF
--- a/src/core/serialize.js
+++ b/src/core/serialize.js
@@ -9,7 +9,7 @@ import { SKIP, _defaultPrimitiveProp } from "../constants"
  * The model schema can be omitted if the object type has a default model schema associated with it.
  * If a list of objects is provided, they should have an uniform type.
  *
- * @param arg1 modelschema to use. Optional
+ * @param arg1 class or modelschema to use. Optional
  * @param arg2 object(s) to serialize
  * @returns {object} serialized representation of the object
  */
@@ -22,8 +22,12 @@ export default function serialize(arg1, arg2) {
             return [] // don't bother finding a schema
         else if (!schema)
             schema = getDefaultModelSchema(thing[0])
+        else if (typeof schema !== "object")
+            schema = getDefaultModelSchema(schema)
     } else if (!schema) {
         schema = getDefaultModelSchema(thing)
+    } else if (typeof schema !== "object") {
+        schema = getDefaultModelSchema(schema)
     }
     invariant(!!schema, "Failed to find default schema for " + arg1)
     if (Array.isArray(thing))

--- a/test/classes.js
+++ b/test/classes.js
@@ -36,8 +36,41 @@ test("schema's can be defined on constructors", t => {
         t2.equal(todos.length, 2)
         t2.deepEqual(_.serialize(todos), jsonlist)
 
+        test("may be used to serialize plain objects", t3 => {
+            jsonlist[0].otherProp = "should not serialize"
+            jsonlist[1].otherProp = "should not serialize"
+
+            t3.throws(() => {
+                _.serialize(jsonlist);
+            }, /Failed to find default schema/)
+
+            _.serialize(Todo, jsonlist).forEach((serialized, i) => {
+                t.equal(serialized.title, jsonlist[i].title)
+                t.equal(serialized.otherProp, undefined)
+            })
+            t3.end()
+        })
+
         t2.end()
     })
+
+    test("may be used to serialize plain objects", t2 => {
+        var source2 = {
+            title: "test",
+            otherProp: "should not serialize"
+        };
+        t2.throws(() => {
+            _.serialize(source2);
+        }, /Failed to find default schema/)
+
+        t.deepEqual(_.serialize(Todo, source2), json)
+        var res2 = _.deserialize(Todo, json)
+        t.equal(res2.title, "test")
+        t.equal(res2.otherProp, undefined)
+        t.equal(res2 instanceof Todo, true)
+
+        t2.end()
+    });
 
     t.end()
 })


### PR DESCRIPTION
## Issue

Attempting to invoke `serialize` with a class and plain object throws an error instead if serializing the plain object using the class's schema as expected. I ran into this issue attempting to serialize the state of a React component (which is just a plain object) in Typescript while using decorators on a class implementing (part) of the component's state interface to define the schema.

## Solution

If the argument passed to `serialize` for the `schema` argument isn't an `object`, use `getDefaultModelSchema` to obtain the schema from the argument.

I did consider `=== "function"` instead of `!== "object"` but the latter seemed more in keeping with the surrounding code's conventions.

Added bonus: `serialize`'s API gains symmetry with `deserialize`:
```js
  json =   serialize(Class, data);
  data = deserialize(Class, json);
```