### PR TITLE
changed type of rootContextCache to WeakMap

### DIFF
--- a/src/core/Context.js
+++ b/src/core/Context.js
@@ -1,6 +1,6 @@
 import { GUARDED_NOOP, once, invariant, isAssignableTo } from "../utils/utils"
 
-var rootContextCache = new Map()
+var rootContextCache = new WeakMap()
 
 export default function Context(parentContext, modelSchema, json, onReadyCb, customArgs) {
     this.parentContext = parentContext


### PR DESCRIPTION
Since there are some problems with garbage collection in the rootContextCache, it could easily mitigated by using a WeakMap.