### PR TITLE
update example for optional doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,16 +629,16 @@ const todo = deserialize(Todo, {
 })
 ```
 
-### _function_ `optional`(_propSchema_?: [PropSchema](#interface-propschemasrc) | boolean): [PropSchema](#interface-propschemasrc) <sub><a href="src/types/optional.ts#L22">src</a></sub>
+### _function_ `optional`(_propSchema_?: [PropSchema](#interface-propschemasrc) | boolean): [PropSchema](#interface-propschemasrc) <sub><a href="src/types/optional.ts#L23">src</a></sub>
 
 Optional indicates that this model property shouldn't be serialized if it isn't present.
 
-Note that if we use `optional` together with another prop schema such as `custom`, the prop schema for `custom` will be applied first and the result of that serialization will be used to feed into `optional`.
+Note that if we use `optional` together with another prop schema such as `custom`, the prop schema for `custom` will be applied first and the result of that serialization will be used to feed into `optional`. As such, it might be better to just use `custom` with `SKIP` to achieve the same goal.
 
 ```ts
 createModelSchema(Todo, {
     title: optional(primitive()),
-    user: optional(custom(value => value.name, () => SKIP))
+    user: optional(custom(value => value?.name, () => SKIP))
 })
 
 serialize(new Todo()) // {}

--- a/src/types/optional.ts
+++ b/src/types/optional.ts
@@ -7,12 +7,13 @@ import { PropSchema } from "../api/types"
  * 
  * Note that if we use `optional` together with another prop schema such as `custom`,
  * the prop schema for `custom` will be applied first and the result of that serialization
- * will be used to feed into `optional`.
+ * will be used to feed into `optional`. As such, it might be better to just use `custom`
+ * with `SKIP` to achieve the same goal.
  *
  * @example
  * createModelSchema(Todo, {
  *     title: optional(primitive()),
- *     user: optional(custom(value => value.name, () => SKIP))
+ *     user: optional(custom(value => value?.name, () => SKIP))
  * })
  *
  * serialize(new Todo()) // {}


### PR DESCRIPTION
@NaridaL updated to a proper example for `optional` and added a note to tell users that they'd better off use `custom` and `SKIP` instead of `optional(custom())`