### PR TITLE
Callback for update function should be optional

### DIFF
--- a/src/core/update.ts
+++ b/src/core/update.ts
@@ -37,7 +37,7 @@ export default function update(
     modelSchema: any,
     target: any,
     json: any,
-    callback: any,
+    callback?: any,
     customArgs?: any
 ) {
     const inferModelSchema = arguments.length === 2 || typeof arguments[2] === "function" // only target and json // callback as third arg


### PR DESCRIPTION
The actual implementation of the `update` function does not make the `callback` parameter optional. It breaks typescript
```js
    update(this.constructor, this, data )// error
```
```
Expected 4-5 arguments, but got 3.ts(2554)
update.d.ts(16, 74): An argument for 'callback' was not provided
```