### PR TITLE
Add support for embedded types

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -11,7 +11,8 @@ export type AdditionalPropArgs = Pick<
 export type PropSerializer = (
     sourcePropertyValue: any,
     key: string | number | symbol,
-    sourceObject: any
+    sourceObject: any,
+    jsonOutput: any
 ) => any | typeof SKIP
 export type PropDeserializer = (
     jsonValue: any,

--- a/src/core/serialize.ts
+++ b/src/core/serialize.ts
@@ -55,7 +55,7 @@ function serializeWithSchema<T>(schema: ModelSchema<T>, obj: any): T {
             return
         }
         if (propDef === true) propDef = _defaultPrimitiveProp
-        const jsonValue = propDef.serializer(obj[key], key, obj)
+        const jsonValue = propDef.serializer(obj[key], key, obj, res)
         if (jsonValue === SKIP) {
             return
         }
@@ -74,7 +74,7 @@ function serializeStarProps(schema: ModelSchema<any>, propDef: PropDef, obj: any
                         target[key] = value
                     }
                 } else {
-                    const jsonValue = propDef.serializer(value, key, obj)
+                    const jsonValue = propDef.serializer(value, key, obj, target)
                     if (jsonValue === SKIP) {
                         return
                     }

--- a/src/serializr.ts
+++ b/src/serializr.ts
@@ -29,5 +29,6 @@ export { default as list } from "./types/list"
 export { default as map } from "./types/map"
 export { default as mapAsArray } from "./types/mapAsArray"
 export { default as raw } from "./types/raw"
+export { default as embedded } from "./types/embedded"
 
 export { SKIP } from "./constants"

--- a/src/types/embedded.ts
+++ b/src/types/embedded.ts
@@ -2,12 +2,15 @@ import deserialize from "../core/deserialize";
 import serialize from "../core/serialize";
 import { SKIP } from "../constants";
 import custom from "./custom";
+import { ClazzOrModelSchema } from "../api/types";
 
-interface Type<T> {
-    new (...args: any[]): T
-}
-
-export default function embedded<T>(type: Type<T>) {
+/**
+ * This allows to embed the property values in the resulting json output
+ * and vice-versa.
+ *
+ * @param type {ClazzOrModelSchema<T>} Some class or model schema.
+ */
+export default function embedded<T>(type: ClazzOrModelSchema<T>) {
     return custom(
         (value, _key, _sourceObject, jsonOutput) => {
             const serialized = serialize(value)

--- a/src/types/embedded.ts
+++ b/src/types/embedded.ts
@@ -1,0 +1,26 @@
+import deserialize from "../core/deserialize";
+import serialize from "../core/serialize";
+import { SKIP } from "../constants";
+import custom from "./custom";
+
+interface Type<T> {
+    new (...args: any[]): T
+}
+
+export default function embedded<T>(type: Type<T>) {
+    return custom(
+        (value, _key, _sourceObject, jsonOutput) => {
+            const serialized = serialize(value)
+            Object.assign(jsonOutput, serialized)
+            return SKIP
+        },
+        (_, context) => {
+            return deserialize(type, context.json)
+        },
+        {
+            beforeDeserialize(callback, jsonValue, jsonParentValue) {
+                callback(null, null)
+            }
+        }
+    )
+}

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -27,13 +27,13 @@ export default function map(
         "provided prop is aliased, please put aliases first"
     )
     let result: PropSchema = {
-        serializer: function (m: Map<any, any> | { [key: string]: any }) {
+        serializer: function (m: Map<any, any> | { [key: string]: any }, _, jsonOutput) {
             invariant(m && typeof m === "object", "expected object or Map")
             const result: { [key: string]: any } = {}
             if (isMapLike(m)) {
-                m.forEach((value, key) => (result[key] = propSchema.serializer(value, key, m)))
+                m.forEach((value, key) => (result[key] = propSchema.serializer(value, key, m, jsonOutput)))
             } else {
-                for (const key in m) result[key] = propSchema.serializer(m[key], key, m)
+                for (const key in m) result[key] = propSchema.serializer(m[key], key, m, jsonOutput)
             }
             return result
         },

--- a/src/types/mapAsArray.ts
+++ b/src/types/mapAsArray.ts
@@ -24,14 +24,14 @@ export default function mapAsArray(
     invariant(isPropSchema(propSchema), "expected prop schema as first argument")
     invariant(!!keyPropertyName, "expected key property name as second argument")
     let result: PropSchema = {
-        serializer: function (m) {
+        serializer: function (m, _, jsonOutput) {
             invariant(m && typeof m === "object", "expected object or Map")
             const result = []
             // eslint-disable-next-line no-unused-vars
             if (isMapLike(m)) {
-                m.forEach((value, key) => result.push(propSchema.serializer(value, key, m)))
+                m.forEach((value, key) => result.push(propSchema.serializer(value, key, m, jsonOutput)))
             } else {
-                for (let key in m) result.push(propSchema.serializer(m[key], key, m))
+                for (let key in m) result.push(propSchema.serializer(m[key], key, m, jsonOutput))
             }
             return result
         },

--- a/src/types/optional.ts
+++ b/src/types/optional.ts
@@ -28,8 +28,8 @@ export default function optional(propSchema?: PropSchema | boolean): PropSchema 
         typeof propSerializer === "function",
         "expected prop schema to have a callable serializer"
     )
-    const serializer: PropSchema["serializer"] = (sourcePropertyValue, key, sourceObject) => {
-        const result = propSerializer(sourcePropertyValue, key, sourceObject)
+    const serializer: PropSchema["serializer"] = (sourcePropertyValue, key, sourceObject, jsonOutput) => {
+        const result = propSerializer(sourcePropertyValue, key, sourceObject, jsonOutput)
         if (result === undefined) {
             return SKIP
         }

--- a/test/typescript/ts.ts
+++ b/test/typescript/ts.ts
@@ -2,6 +2,7 @@ import {
     serializable,
     alias,
     date,
+    embedded,
     list,
     map,
     mapAsArray,
@@ -18,6 +19,7 @@ import {
     custom,
     AdditionalPropArgs,
     SKIP,
+    createModelSchema,
 } from "../../"
 
 import { observable, autorun } from "mobx"
@@ -713,5 +715,46 @@ test("list(custom(...)) with SKIP", (t) => {
 
     t.deepEqual(deserialize(Store, { list: [1, 2, 3] }), { list: [1, 3] })
 
+    t.end()
+})
+
+test("embedded(type)", (t) => {
+    class PhoneNumber {
+        constructor(
+            public number: string,
+            public extension?: string) {
+
+        }
+    }
+
+    class Company {
+        constructor(
+            public name: string,
+            public phone: PhoneNumber) {
+
+        }
+    }
+
+    createModelSchema(PhoneNumber, {
+        number: primitive(),
+        extension: optional(primitive())
+    });
+
+    createModelSchema(Company, {
+        name: primitive(),
+        phone: embedded(PhoneNumber)
+    })
+
+    const person = new Company('The Company', new PhoneNumber('+55123456789'))
+    const serialized = serialize(person)
+
+    t.deepEqual(serialized, {
+        name: person.name,
+        number: person.phone.number
+    })
+
+    const deserialized = deserialize(Company, serialized)
+
+    t.deepEqual(deserialized, person)
     t.end()
 })


### PR DESCRIPTION
These changes will allow support for embedded types or maybe more powerful custom serializers.
It allows the user to change the outputted object during the serialization/deserialization.

- A new custom type was created too (embedded), which embed the object data into the parent resulting JSON (and vice-versa).