### PR TITLE
Fix serializations of nulls in list

### DIFF
--- a/src/types/list.ts
+++ b/src/types/list.ts
@@ -54,10 +54,16 @@ export default function list(
             if (ar === undefined) {
                 return SKIP;
             }
+            if (ar === null) {
+                return null;
+            }
+
             invariant(ar && "length" in ar && "map" in ar, "expected array (like) object");
             return ar.map(propSchema.serializer);
         },
         deserializer: function (jsonArray, done, context) {
+            if (jsonArray === null) return void done(null, jsonArray);
+
             if (!Array.isArray(jsonArray)) return void done("[serializr] expected JSON array");
 
             function processItem(

--- a/test/simple.js
+++ b/test/simple.js
@@ -333,6 +333,19 @@ test("it should respect lists", (t) => {
     t.end()
 })
 
+test("it should respect lists when null", (t) => {
+    var schema = _.createSimpleSchema({
+        x: _.list(primitive()),
+    })
+
+    var source = { x: null }
+    var json = source
+    t.deepEqual(serialize(schema, source), json)
+    t.deepEqual(deserialize(schema, json), source)
+
+    t.end()
+})
+
 test("it should respect childs", (t) => {
     var childSchema = _.createSimpleSchema({
         x: primitive(),


### PR DESCRIPTION
When a field list(primitive()) is null, it fails to serialize/deserialize it.

This handles the null case, same as the `object` implementation