### PR TITLE
Fixed property key attribution in generic `createSimpleSchema<T>`

### DIFF
--- a/src/api/createSimpleSchema.ts
+++ b/src/api/createSimpleSchema.ts
@@ -16,7 +16,7 @@ import { Props, ModelSchema } from "./types";
  * @param props property mapping,
  * @returns model schema
  */
-export default function createSimpleSchema<T extends object>(props: Props): ModelSchema<T> {
+export default function createSimpleSchema<T extends object>(props: Props<T>): ModelSchema<T> {
     return {
         factory: function () {
             return {} as any;


### PR DESCRIPTION
While using `createSimpleSchema<T>` I had noticed that key/property validation wasn't working and had a peek at the typings.

I noticed that while `T` was accepted as a generic, it was not used with regard to the `property` mappings provided, so a 3 character change was made :)